### PR TITLE
Renovate と Dependabot の auto-merge 設定を追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge --auto --merge --repo "$GH_REPO" "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,31 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "automergeStrategy": "merge-commit",
+  "packageRules": [
+    {
+      "description": "信頼できる GitHub Actions の minor/patch/digest は automerge",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-go",
+        "codecov/codecov-action",
+        "jdx/mise-action",
+        "Kesin11/actions-timeline",
+        "release-drafter/release-drafter",
+        "tj-actions/coverage-badge-go",
+        "tj-actions/verify-changed-files"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## 概要

このリポジトリは Renovate / Dependabot がどちらも稼働していますが、auto-merge が一切設定されておらず、依存更新 PR が手動マージ待ちで滞留しています。kaki-org/baukis2・kaki-org/taskleaf と同じ方針で auto-merge を設定します。

## 変更内容

### `renovate.json`
- 信頼できる GitHub Actions の `minor` / `patch` / `digest` 更新のみ automerge する `packageRules` を追加
- 対象は本リポジトリで実際に使用している action に限定した許可リスト方式（baukis2 / taskleaf と同じ方針）
- `automergeStrategy: merge-commit` を指定（本リポジトリは squash / rebase が無効なため）

### `.github/workflows/dependabot-auto-merge.yml`（新規）
- Dependabot の PR に GitHub の auto-merge を有効化する
- `dependabot/fetch-metadata` で更新種別を判定し、`version-update:semver-major` は auto-merge しない

## 前提: branch protection

auto-merge は「マージ可能になった時点で自動マージ」する機能のため、required status checks が無いと CI 完了を待たずに即マージされます。そのため本 PR とは別に、`develop` ブランチへ以下を設定済みです。

- required status checks: `build`（`.github/workflows/build.yml`）
- strict（base への追従必須）は無効
- required approving reviews は従来どおり 0 件のまま

## 補足 / 別途対応が必要な点

- **Renovate と Dependabot が両方 `github-actions` を見ています。** 同じ action の更新 PR が両方の bot から重複して作られている状態です（例: `jdx/mise-action` の更新 PR が両方から出ています）。auto-merge を入れると重複 PR も自動マージされ、片方は空更新になります。どちらか一方に寄せる整理は本 PR のスコープ外としています。
- baukis2 / taskleaf の既存 `dependabot-auto-merge.yml` は PR タイトルに `major` の文字が含まれるかで判定していますが、Dependabot のタイトルに `major` は入らないため実質 major も auto-merge されます。本 PR では `dependabot/fetch-metadata` を使った公式パターンを採用しています。既存 2 リポジトリの修正は別 PR で対応します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated safe maintenance updates can now be merged without manual intervention.
  * Major version updates continue to require review before merging.
  * Trusted automation updates are handled consistently through the project’s maintenance workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->